### PR TITLE
Fix markdown rendering inside <details> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ or from source
 </br>
 
 <details>
-<Summary>
+<summary>
 And install docker if you don't have it already
-</Summary>
-* Download the [Docker Mac App](https://www.docker.com/docker-mac). 
+</summary>
+
+* Download the [Docker Mac App](https://www.docker.com/docker-mac).
 * Alternatively install via homebrew `brew install docker`
 </details>
 


### PR DESCRIPTION
Needed to add a newline to force GitHub to render the bullets and url properly ¯\_(ツ)_/¯. Also removed the capitalisation in "summary" because I am a pedant